### PR TITLE
Fix the bug that an error occurs if the spin button is removed.

### DIFF
--- a/app/components/spin-button.js
+++ b/app/components/spin-button.js
@@ -73,7 +73,11 @@ export default Ember.Component.extend({
 
       if (Ember.isPresent(actionResult) &&
           ('function' === typeof actionResult.finally)) {
-        actionResult.finally(() => { this.set('inFlight', false); });
+        actionResult.finally(() => {
+          if (!this.get('isDestroyed')) {
+            this.set('inFlight', false);
+          }
+        });
       }
     }else{
       this.sendAction('action');


### PR DESCRIPTION
A JS error occurs if the button is removed by the action triggered by the button itself.