### PR TITLE
Fix a hanging problem happening when the promise is resolved before the spinner is created.

### DIFF
--- a/app/components/spin-button.js
+++ b/app/components/spin-button.js
@@ -91,6 +91,7 @@ export default Ember.Component.extend({
     var inFlight = this.get('inFlight');
 
     if (inFlight) {
+      this.resetTimer()
       if (this.get('startDelay') > 4) {
         Ember.run.later(this, this.createSpinner, element, this.get('startDelay'));
       }else{
@@ -106,7 +107,9 @@ export default Ember.Component.extend({
       this._spinner = createSpinner( element );
       this._spinner.spin(element.querySelector('.spin-button-spinner'));
     }
+  },
 
+  resetTimer: function() {
     if(this._timer) { Ember.run.cancel(this._timer); }
     var timeout = this.get('defaultTimout');
     if (timeout > 4) {


### PR DESCRIPTION
This fixes the component spinning too long when the promise is resolved before the spinner is created. This typically happens in tests or if the startDelay is too long. The promise getting resolved triggers the setEnabled function before createSpinner is called, and the component spins until the timeout is reached.